### PR TITLE
Improve the docs format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Even though the field value is defined as type `interface{}`, its concrete type 
 * `[]map[string]string` type -> For variables declared as List, but with nested regexes. ex. `Value List person ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)`
 * `string` type -> For every other variable type. This is most common use case.
 
-### Example code to handle the output - Option 1
+### Option 1 - Example code to handle the output
 Following complete code snippet shows an example of how to process the output of parser.
 ```
 package main
@@ -158,7 +158,7 @@ Gandhi: 150 NV
 }
 ```
 
-### Example code to handle the output - Option 2
+### Option 2 - Example code to handle the output
 You can also marshal the resulting dict to json (or yaml) if that make is easier for you to handle the output.
 ```
 	str, err := json.Marshal(parser.Dict)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TextFSM is a template-based state machine for parsing semi-formatted text.
 It was originally developed to allow programmatic access to information returned
 from the command line interface (CLI) of networking devices.
 
-The complete documentation about TextFSM is given here: https://github.com/google/textfsm/wiki/TextFSM
+The complete documentation of TextFSM can be found at the [TextFSM Wiki](https://github.com/google/textfsm/wiki/TextFSM).
 
 This porting attempts to be 100% compatible to the original TextFSM specification given in the above links.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 (https://github.com/networktocode/ntc-templates)
 
 ## Differences with Python's implementation
-Following are the differences between this implementation of TextFSM and the original Python implementation:
+The following are the differences between this implementation of TextFSM and the original Python implementation:
 * Python's implementation provides 2 ways of getting results.
     * Output as a list of lists (outer list represents a record and inner list contains the values. - in the order the Values declared)
     * Output as a list of dicts.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gotextfsm
 
-This is a golang implementation (or version) of Google's TextFSM library.
+This is a Golang implementation (or version) of Google's TextFSM library.
 
 TextFSM is a template-based state machine for parsing semi-formatted text.
 It was originally developed to allow programmatic access to information returned
@@ -196,7 +196,7 @@ The following are the differences between this implementation of TextFSM and the
     * texttable
 
 ## Caveats
-There are differences in golang's regular expression implementation and Python's.
+There are differences in Golang's regular expression implementation and Python's.
 
 :warning: Because of this reason, some templates that are valid in Python fail parsing in gotextfsm.
 
@@ -205,9 +205,9 @@ There are differences in golang's regular expression implementation and Python's
 
 > [!IMPORTANT]
 > Following are some of the known examples:
-> * golang restricts repeat count to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
+> * Golang restricts repeat count to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
 > More details about this are discussed at https://github.com/golang/go/issues/7252
-> * golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences
+> * Golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences
 >     * Perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 
 ## Highlights:
 
-* Attempts to be 100% compatible with TextFSM original TextFSM implementation (See differences section)
+* Attempts to be 100% compatible with the original TextFSM implementation (See [differences section](#differences-with-pythons-implementation))
 * Very nimble code with zero external dependencies on any other libraries.
 * Well tested (~ 97% code coverage) *>1740 Test cases executed!!!*
     * All test cases of Python's implementation are ported and executed
@@ -184,7 +184,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 (https://github.com/networktocode/ntc-templates)
 
 ## Differences with Python's implementation
-Following are the differences between this implementation of TextFSM and original implementation of Python:
+Following are the differences between this implementation of TextFSM and the original Python implementation:
 * Python's implementation provides 2 ways of getting results.
     * Output as a list of lists (outer list represents a record and inner list contains the values. - in the order the Values declared)
     * Output as a list of dicts.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Textfsm is a template based state machine for parsing semi-formatted text. Origi
 
 The complete documentation about text fsm is given here: https://github.com/google/textfsm/wiki/TextFSM
 
-The source code of textfsm in python is given here: https://github.com/google/textfsm
+The source code of textfsm in Python is given here: https://github.com/google/textfsm
 
 This porting attempts to be 100% compatible to the original textfsm specification given in the above links.
 
@@ -178,7 +178,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 * Attempts to be 100% compatible with textfsm original textfsm implementation (See differences section)
 * Very nimble code with zero external dependencies on any other libraries.
 * Well tested (~ 97% code coverage) *>1740 Test cases executed!!!*
-    * All test cases of python's implementation are ported and executed
+    * All test cases of Python's implementation are ported and executed
     * More test cases added as well to test corner cases
 * All the test cases of ntc-templates are executed.
 	* Out of 1578 test cases of ntc-templates, 28 of them are failing (All of them due to reasons listed in `Caveats` Section)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a golang implementation (or version) of Google's TextFSM library.
 
-Textfsm is a template based state machine for parsing semi-formatted text. Originally developed to allow programmatic access to information returned from the command line interface (CLI) of networking devices.
+TextFSM is a template-based state machine for parsing semi-formatted text.
+It was originally developed to allow programmatic access to information returned
+from the command line interface (CLI) of networking devices.
 
 The complete documentation about TextFSM is given here: https://github.com/google/textfsm/wiki/TextFSM
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # gotextfsm
 
-This is a Golang implementation (or version) of Google's TextFSM library.
+This is a Golang implementation (or version) of Google's [TextFSM](https://github.com/google/textfsm)
+Python library.
 
 TextFSM is a template-based state machine for parsing semi-formatted text.
 It was originally developed to allow programmatic access to information returned
 from the command line interface (CLI) of networking devices.
 
 The complete documentation about TextFSM is given here: https://github.com/google/textfsm/wiki/TextFSM
-
-The source code of TextFSM in Python is given here: https://github.com/google/textfsm
 
 This porting attempts to be 100% compatible to the original TextFSM specification given in the above links.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # gotextfsm
 
-This is a golang implementation (or version) of Google's textfsm library.
+This is a golang implementation (or version) of Google's TextFSM library.
 
 Textfsm is a template based state machine for parsing semi-formatted text. Originally developed to allow programmatic access to information returned from the command line interface (CLI) of networking devices.
 
-The complete documentation about text fsm is given here: https://github.com/google/textfsm/wiki/TextFSM
+The complete documentation about TextFSM is given here: https://github.com/google/textfsm/wiki/TextFSM
 
-The source code of textfsm in Python is given here: https://github.com/google/textfsm
+The source code of TextFSM in Python is given here: https://github.com/google/textfsm
 
-This porting attempts to be 100% compatible to the original textfsm specification given in the above links.
+This porting attempts to be 100% compatible to the original TextFSM specification given in the above links.
 
 ## Get Started
 Get the library:
@@ -174,7 +174,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 
 ## Highlights:
 
-* Attempts to be 100% compatible with textfsm original textfsm implementation (See differences section)
+* Attempts to be 100% compatible with TextFSM original TextFSM implementation (See differences section)
 * Very nimble code with zero external dependencies on any other libraries.
 * Well tested (~ 97% code coverage) *>1740 Test cases executed!!!*
     * All test cases of Python's implementation are ported and executed

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ There are differences in golang's regular expression implementation and Python's
 > * golang restricts repeat count to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
 > More details about this are discussed at https://github.com/golang/go/issues/7252
 > * golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences
->     * perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error
+>     * Perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error
 
 ## Testing
 ```

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The following are the differences between this implementation of TextFSM and the
     * Output as a list of lists (outer list represents a record and inner list contains the values. - in the order the Values declared)
     * Output as a list of dicts.
   This implementation provides the output as only slice of maps. It does not provide as slice of slices.
-* [TODO]This implementation (currently) implements the core TextFSM Functionality. It does not implement the following 
+* [TODO]This implementation (currently) implements the core TextFSM functionality. It does not implement the following 
     * clitable
     * terminal
     * texttable

--- a/README.md
+++ b/README.md
@@ -13,16 +13,22 @@ The source code of TextFSM in Python is given here: https://github.com/google/te
 This porting attempts to be 100% compatible to the original TextFSM specification given in the above links.
 
 ## Get Started
+
 Get the library:
+
 ```
 $ go get github.com/sirikothe/gotextfsm
 ```
 ### Basic Usage
-Import the gotextfsm library
+
+Import the gotextfsm library:
+
 ```
 import "github.com/sirikothe/gotextfsm"
 ```
-Create a TextFSM Object and parse the template
+
+Create a TextFSM Object and parse the template:
+
 ```
   fsm := gotextfsm.TextFSM{}
   # template should hold the string of the Textfsm to be parsed.
@@ -30,18 +36,20 @@ Create a TextFSM Object and parse the template
   # err will be nil if the parsing of the template is successful. 
   # If will contain error object if the parsing failed.
 ```
-Parse a raw input string using the fsm object created
+
+Parse a raw input string using the fsm object created:
+
 ```
   parser := gotextfsm.ParserOutput{}
   err = parser.ParseTextString(input, fsm, true)
   # err will be nil if the parsing of the input (as per the fsm provided) is successful. 
   # If will contain error object if the parsing failed.
 ```
-At the end of the parsing of input, the parser's Dict object contains the results
 
+At the end of the parsing of input, the parser's Dict object contains the results.
 
+### Complete Example Code
 
-### Complete Example code:
 ```
 package main
 
@@ -72,21 +80,26 @@ Start
 	fmt.Printf("Parsed output: %v\n", parser.Dict)
 }
 ```
+
 ## How to read results of parsing
+
 The defined type for ParserOutput.Dict is `[]map[string]interface{}`.
 
 This is an array of maps. Each element in array represents a record of parsed output.
 
-Each record is of type `map[string]interface{}`, where the key is the field name (type string) and value is the field value (type interface{})
+Each record is of type `map[string]interface{}`, where the key is the field name (type string) and value is the field value (type interface{}).
 
-Even though the field value is defined as type `interface{}`, its concrete type is one of
+Even though the field value is defined as type `interface{}`, its concrete type is one of:
+
 * `[]string` type -> For variables declared as `List` in the definition. ex. `Value List ifnames (\w+)`
 * `map[string]string` type -> For variables declared as scalar, but with nested regexes. ex. `Value person ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)`
 * `[]map[string]string` type -> For variables declared as List, but with nested regexes. ex. `Value List person ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)`
 * `string` type -> For every other variable type. This is most common use case.
 
 ### Option 1 - Example code to handle the output
+
 Following complete code snippet shows an example of how to process the output of parser.
+
 ```
 package main
 
@@ -160,7 +173,9 @@ Gandhi: 150 NV
 ```
 
 ### Option 2 - Example code to handle the output
+
 You can also marshal the resulting dict to json (or yaml) if that make is easier for you to handle the output.
+
 ```
 	str, err := json.Marshal(parser.Dict)
 	if err != nil {
@@ -169,33 +184,38 @@ You can also marshal the resulting dict to json (or yaml) if that make is easier
 		fmt.Printf("JSON: %s\n", str)
 	}
 ```
+
 Output from the above example:
+
 ```
 JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"persons":[{"age":"50","name":"Siri","state":"CA"},{"age":"22","name":"Raj","state":"NM"},{"age":"150","name":"Gandhi","state":"NV"}],"state_abbr":{"abbr":"CA","fullstate":"California"}}]
 ```
 
-## Highlights:
+## Highlights
 
-* Attempts to be 100% compatible with the original TextFSM implementation (See [differences section](#differences-with-pythons-implementation))
+* Attempts to be 100% compatible with the original TextFSM implementation (See [differences section](#differences-with-pythons-implementation)).
 * Very nimble code with zero external dependencies on any other libraries.
 * Well tested (~ 97% code coverage) *>1740 Test cases executed!!!*
-    * All test cases of Python's implementation are ported and executed
-    * More test cases added as well to test corner cases
+    * All test cases of Python's implementation are ported and executed.
+    * More test cases added as well to test corner cases.
 * All the test cases of ntc-templates are executed.
-	* Out of 1578 test cases of [ntc-templates](https://github.com/networktocode/ntc-templates), 28 of them are failing (All due to reasons listed in [Caveats](#caveats))
+	* Out of 1578 test cases of [ntc-templates](https://github.com/networktocode/ntc-templates), 28 of them are failing (All due to reasons listed in [Caveats](#caveats)).
 
 ## Differences with Python's implementation
+
 The following are the differences between this implementation of TextFSM and the original Python implementation:
+
 * Python's implementation provides 2 ways of getting results.
-    * Output as a list of lists (outer list represents a record and inner list contains the values. - in the order the Values declared)
+    * Output as a list of lists (outer list represents a record and inner list contains the values in the order they were declared).
     * Output as a list of dicts.
   This implementation provides the output as only slice of maps. It does not provide as slice of slices.
-* [TODO]This implementation (currently) implements the core TextFSM functionality. It does not implement the following 
+* [TODO]This implementation (currently) implements the core TextFSM functionality. It does ***not*** implement the following:
     * clitable
     * terminal
     * texttable
 
 ## Caveats
+
 There are differences in Golang's regular expression implementation and Python's.
 
 :warning: Because of this reason, some templates that are valid in Python fail parsing in gotextfsm.
@@ -205,12 +225,14 @@ There are differences in Golang's regular expression implementation and Python's
 
 > [!IMPORTANT]
 > Following are some of the known examples:
+> 
 > * Golang restricts repeat count to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
 > More details about this are discussed at https://github.com/golang/go/issues/7252
-> * Golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences
->     * Perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error
+> * Golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences.
+>     * Perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error.
 
 ## Testing
+
 ```
 PS C:\Users\siri\code\nuviso\GitHub\gotextfsm> go test -v
 === RUN   TestParseText

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # gotextfsm
-golang implementation of Google's textfsm library
 
-This is a golang version of Google's textfsm library.
+This is a golang implementation (or version) of Google's textfsm library.
 
 Textfsm is a template based state machine for parsing semi-formatted text. Originally developed to allow programmatic access to information returned from the command line interface (CLI) of networking devices.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gotextfsm
-golang implementation of google's textfsm library
+golang implementation of Google's textfsm library
 
-This is a golang version of google's textfsm library.
+This is a golang version of Google's textfsm library.
 
 Textfsm is a template based state machine for parsing semi-formatted text. Originally developed to allow programmatic access to information returned from the command line interface (CLI) of networking devices.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Even though the field value is defined as type `interface{}`, its concrete type 
 * `map[string]string` type -> For variables declared as scalar, but with nested regexes. ex. `Value person ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)`
 * `[]map[string]string` type -> For variables declared as List, but with nested regexes. ex. `Value List person ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)`
 * `string` type -> For every other variable type. This is most common use case.
-#### Example code to handle the output - Option 1
+
+### Example code to handle the output - Option 1
 Following complete code snippet shows an example of how to process the output of parser.
 ```
 package main

--- a/README.md
+++ b/README.md
@@ -207,12 +207,11 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
 The following are the differences between this implementation of TextFSM and the original Python implementation:
 
 * Python's implementation provides 2 ways of getting results.
-    * Output as a list of lists (outer list represents a record and inner list contains the values in the order they were declared).
+    * Output as a list of lists.
+        * The outer list represents a record and inner list contains the values in the order they were declared.
     * Output as a list of dicts.
-
-  This Golang implementation provides the output as only slice of maps. It does not provide as slice of slices.
-
-* [TODO]This implementation (currently) implements the core TextFSM functionality. It does ***not*** implement the following:
+        * This Golang implementation provides the output as only slice of maps. It does not provide a slice of slices.
+* [TODO] :construction: This Golang implementation (currently) implements the core TextFSM functionality. It does ***not*** implement the following:
     * clitable
     * terminal
     * texttable
@@ -221,7 +220,7 @@ The following are the differences between this implementation of TextFSM and the
 
 There are differences in Golang's regular expression implementation and Python's.
 
-:warning: Because of this reason, some templates that are valid in Python fail parsing in gotextfsm.
+:warning: Because of this reason some templates that are valid in Python fail parsing in gotextfsm.
 
 > [!TIP]
 > Supported regular expression sytnax are those provided by the [`re2` library](https://github.com/google/re2/wiki/Syntax)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Gandhi: 150 NV
 
 ### Option 2 - Example code to handle the output
 
-You can also marshal the resulting dict to json (or yaml) if that make is easier for you to handle the output.
+You can also marshal the resulting dict to json (or yaml) if that makes it easier for you to handle the output.
 
 ```go
 	str, err := json.Marshal(parser.Dict)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ There are differences in golang's regular expression implementation and Python's
 
 > [!IMPORTANT]
 > Following are some of the known examples:
-> * golang restricts repeat cound to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
+> * golang restricts repeat count to be 1000 while Python allows it to be 2^^16 -1. Because of this reason, the regular expressions like `Value SAP_COUNT ([0-9]{1,1500})` throw an error.
 > More details about this are discussed at https://github.com/golang/go/issues/7252
 > * golang does not support negative or positive [lookahead or lookbehind](https://github.com/golang/go/issues/18868) nor backreferences
 >     * perl syntax like `(?<`. The regex like `Value NAME (\S.*(?<!\s))` throws an error

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Start
 `
 	input := `Continent: North America
 Country: USA
-Country: Candada
+Country: Canada
 Country: Mexico
 State: California: CA
 Siri: 50 CA
@@ -170,7 +170,7 @@ You can also marshal the resulting dict to json (or yaml) if that make is easier
 ```
 Output from the above example:
 ```
-JSON: [{"continent":"North America","countries":["USA","Candada","Mexico"],"persons":[{"age":"50","name":"Siri","state":"CA"},{"age":"22","name":"Raj","state":"NM"},{"age":"150","name":"Gandhi","state":"NV"}],"state_abbr":{"abbr":"CA","fullstate":"California"}}]
+JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"persons":[{"age":"50","name":"Siri","state":"CA"},{"age":"22","name":"Raj","state":"NM"},{"age":"150","name":"Gandhi","state":"NV"}],"state_abbr":{"abbr":"CA","fullstate":"California"}}]
 ```
 
 ## Highlights:

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"perso
     * All test cases of Python's implementation are ported and executed
     * More test cases added as well to test corner cases
 * All the test cases of ntc-templates are executed.
-	* Out of 1578 test cases of ntc-templates, 28 of them are failing (All of them due to reasons listed in `Caveats` Section)
-(https://github.com/networktocode/ntc-templates)
+	* Out of 1578 test cases of [ntc-templates](https://github.com/networktocode/ntc-templates), 28 of them are failing (All due to reasons listed in [Caveats](#caveats))
 
 ## Differences with Python's implementation
 The following are the differences between this implementation of TextFSM and the original Python implementation:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Parse a raw input string using the fsm object created:
   # If will contain error object if the parsing failed.
 ```
 
-At the end of the parsing of input, the parser's Dict object contains the results.
+At the end of the parsing of input the parser's Dict object contains the results.
 
 ### Complete Example Code
 
@@ -87,7 +87,7 @@ The defined type for ParserOutput.Dict is `[]map[string]interface{}`.
 
 This is an array of maps. Each element in array represents a record of parsed output.
 
-Each record is of type `map[string]interface{}`, where the key is the field name (type string) and value is the field value (type interface{}).
+Each record is of type `map[string]interface{}` where the key is the field name (type string) and value is the field value (type interface{}).
 
 Even though the field value is defined as type `interface{}`, its concrete type is one of:
 
@@ -209,7 +209,9 @@ The following are the differences between this implementation of TextFSM and the
 * Python's implementation provides 2 ways of getting results.
     * Output as a list of lists (outer list represents a record and inner list contains the values in the order they were declared).
     * Output as a list of dicts.
-  This implementation provides the output as only slice of maps. It does not provide as slice of slices.
+
+  This Golang implementation provides the output as only slice of maps. It does not provide as slice of slices.
+
 * [TODO]This implementation (currently) implements the core TextFSM functionality. It does ***not*** implement the following:
     * clitable
     * terminal

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ $ go get github.com/sirikothe/gotextfsm
 
 Import the gotextfsm library:
 
-```
+```go
 import "github.com/sirikothe/gotextfsm"
 ```
 
 Create a TextFSM Object and parse the template:
 
-```
+```go
   fsm := gotextfsm.TextFSM{}
   # template should hold the string of the Textfsm to be parsed.
   err := fsm.ParseString(template)
@@ -39,7 +39,7 @@ Create a TextFSM Object and parse the template:
 
 Parse a raw input string using the fsm object created:
 
-```
+```go
   parser := gotextfsm.ParserOutput{}
   err = parser.ParseTextString(input, fsm, true)
   # err will be nil if the parsing of the input (as per the fsm provided) is successful. 
@@ -50,7 +50,7 @@ At the end of the parsing of input, the parser's Dict object contains the result
 
 ### Complete Example Code
 
-```
+```go
 package main
 
 import (
@@ -100,7 +100,7 @@ Even though the field value is defined as type `interface{}`, its concrete type 
 
 Following complete code snippet shows an example of how to process the output of parser.
 
-```
+```go
 package main
 
 import (
@@ -121,6 +121,7 @@ Start
 	^State: ${state_abbr}
 	^${persons}
 `
+
 	input := `Continent: North America
 Country: USA
 Country: Canada
@@ -164,7 +165,7 @@ Gandhi: 150 NV
 				// ex: Value List persons ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)
 				fmt.Printf("%s: %s\n", key, value.([]map[string]string))
 			default:
-				// Shoule never happen.
+				// Should never happen.
 				panic("Really?")
 			}
 		}
@@ -176,7 +177,7 @@ Gandhi: 150 NV
 
 You can also marshal the resulting dict to json (or yaml) if that make is easier for you to handle the output.
 
-```
+```go
 	str, err := json.Marshal(parser.Dict)
 	if err != nil {
 		fmt.Printf("Unable to convert dict to json \n", err)
@@ -187,7 +188,7 @@ You can also marshal the resulting dict to json (or yaml) if that make is easier
 
 Output from the above example:
 
-```
+```go
 JSON: [{"continent":"North America","countries":["USA","Canada","Mexico"],"persons":[{"age":"50","name":"Siri","state":"CA"},{"age":"22","name":"Raj","state":"NM"},{"age":"150","name":"Gandhi","state":"NV"}],"state_abbr":{"abbr":"CA","fullstate":"California"}}]
 ```
 


### PR DESCRIPTION
resolves #10

* Fix some typos / misspelling
* Modify Option 1 header level
* Move option numbers to beginning of line to make it evident the either or nature
* Capitalize some formal nouns (project names, company)
* Consolidate some text or grammar
* Integrate some hyperlinks into words
* Change a non-formal noun to lowercase (ex: functionality)
* Modify punctuation
* Add code fence syntax highlighting