### PR TITLE
Remove unneeded regex parentheses check

### DIFF
--- a/value.go
+++ b/value.go
@@ -65,12 +65,7 @@ func (value *TextFSMValue) Parse(input string, line_num int) error {
 	if len(value.Name) > MAX_NAME_LENG {
 		return fmt.Errorf("%d Line: Invalid Value name '%s' or name too long.", line_num, value.Name)
 	}
-	square_brackets := regexp.MustCompile(`([^\\]?)\[[^]]*]`)
-	regex_without_brackets := square_brackets.ReplaceAllString(value.Regex, "$1")
 	if !regexp.MustCompile(`^\(.*\)$`).MatchString(value.Regex) {
-		return fmt.Errorf("%d Line: Value '%s' must be contained within a '()' pair.", line_num, value.Regex)
-	}
-	if strings.Count(regex_without_brackets, "(") != strings.Count(regex_without_brackets, ")") {
 		return fmt.Errorf("%d Line: Value '%s' must be contained within a '()' pair.", line_num, value.Regex)
 	}
 	if _, err := regexp.Compile(value.Regex); err != nil {

--- a/value_test.go
+++ b/value_test.go
@@ -185,6 +185,11 @@ var valTestCases = []valTestCase{
 		regex: `(\\S+Δ)`,
 	},
 	{
+		input: `Value para_beer (\()`,
+		name:  "para_beer",
+		regex: `(\()`,
+	},
+	{
 		// Test regular expression with []
 		input: `Value beer ([(\S+\s\S+)]+)`,
 		name:  "beer",


### PR DESCRIPTION
Hi,
I'm not sure [this](https://github.com/sirikothe/gotextfsm/blob/master/value.go#L73) if statement to count the number of parentheses is needed, considering the `^\(.*\)$` regex if statement just above it checks that the value begins and ends with parentheses. The one after ensures the regex is syntactically correct. It also breaks the legitimate use of parentheses escaped with `\(` or `\)` which I also add a test for.