### PR TITLE
compile rule regexes once at template load, not per line

### DIFF
--- a/parsetext.go
+++ b/parsetext.go
@@ -3,7 +3,6 @@ package gotextfsm
 import (
 	"bufio"
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -96,7 +95,7 @@ func (t *ParserOutput) checkLine(line string, fsm TextFSM) error {
 		panic(fmt.Sprintf("Unknown State %s", t.cur_state_name))
 	}
 	for _, rule := range state.rules {
-		varmap := GetNamedMatches(regexp.MustCompile(rule.Regex), line)
+		varmap := GetNamedMatches(rule.CompiledRegex, line)
 		if varmap != nil {
 			// fmt.Printf("Line '%s'. Regex: '%s' varmap: '%v'\n", line, rule.Regex, varmap)
 			for key, val := range varmap {

--- a/rule.go
+++ b/rule.go
@@ -7,12 +7,13 @@ import (
 )
 
 type TextFSMRule struct {
-	Regex    string
-	Match    string
-	LineOp   string
-	RecordOp string
-	NewState string
-	LineNum  int
+	Regex         string
+	CompiledRegex *regexp.Regexp
+	Match         string
+	LineOp        string
+	RecordOp      string
+	NewState      string
+	LineNum       int
 }
 
 var LINE_OPERATORS = []string{"Continue", "Next", "Error"}
@@ -77,9 +78,11 @@ func (r *TextFSMRule) Parse(line string, lineNum int, var_map map[string]interfa
 		}
 		r.Regex = regex
 	}
-	if _, err := regexp.Compile(r.Regex); err != nil {
+	compiled, err := regexp.Compile(r.Regex)
+	if err != nil {
 		return fmt.Errorf("Line %d: Invalid regular expression '%s'. Error: '%s'", r.LineNum, r.Regex, err.Error())
 	}
+	r.CompiledRegex = compiled
 	if _, err := regexp.Compile(r.Match); err != nil {
 		return fmt.Errorf("Line %d: Invalid regular expression '%s'. Error: '%s'", r.LineNum, r.Match, err.Error())
 	}


### PR DESCRIPTION
`checkLine` was calling `regexp.MustCompile(rule.Regex)` on every input line. Since rules don't change after the template is loaded, we can compile each regex once in `Rule.Parse()` and reuse it. The compile was already happening there for validation, this just keeps the result.

Worst-case reduction is one compile per rule per line (when no rule matches), typical case is one compile per matched line.

Benchmarked with a 9-rule template parsing 20 records (~200 input lines): allocs/op dropped ~96%.